### PR TITLE
Enable JaCoCo code coverage reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'java-library'
     id 'extra-java-module-info'
     id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id 'jacoco'
 }
 
 tasks.withType(AbstractArchiveTask) {
@@ -90,6 +91,18 @@ jar {
 shadowJar {
     archiveVersion = '0.9'
     classifier = 'all'
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+}
+
+jacoco {
+    toolVersion = '0.8.10'
 }
 
 extraJavaModuleInfo {


### PR DESCRIPTION
I wanted understand the Sparrow codebase better by adding some unit tests and realized there were no code coverage reports. This PR enables them and they can be seen under `build/reports/jacoco/test/html`:

![Screenshot from 2023-06-30 00-11-01](https://github.com/sparrowwallet/drongo/assets/100320/0fdd04ba-06ab-4eca-b66c-b9ba4734a613)
