### PR TITLE
Add Satochip support

### DIFF
--- a/src/main/java/com/sparrowwallet/drongo/crypto/ECKey.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ECKey.java
@@ -308,6 +308,13 @@ public class ECKey {
     }
 
     /**
+     * Gets the raw public key value in compressed or uncompressed form. This is needed by Satochip
+     */
+    public byte[] getPubKey(Boolean compressed) {
+        return pub.getEncoded(compressed);
+    }
+
+    /**
      * Gets the x coordinate of the raw public key value. This appears in transaction scriptPubKeys for Taproot outputs.
      */
     public byte[] getPubKeyXCoord() {

--- a/src/main/java/com/sparrowwallet/drongo/wallet/WalletModel.java
+++ b/src/main/java/com/sparrowwallet/drongo/wallet/WalletModel.java
@@ -4,7 +4,7 @@ import java.util.Locale;
 
 public enum WalletModel {
     SEED, SPARROW, BITCOIN_CORE, ELECTRUM, TREZOR_1, TREZOR_T, COLDCARD, LEDGER_NANO_S, LEDGER_NANO_X, DIGITALBITBOX_01, KEEPKEY, SPECTER_DESKTOP, COBO_VAULT,
-    BITBOX_02, SPECTER_DIY, PASSPORT, BLUE_WALLET, KEYSTONE, SEEDSIGNER, CARAVAN, GORDIAN_SEED_TOOL, JADE, LEDGER_NANO_S_PLUS, EPS, TAPSIGNER, SATSCARD, LABELS, BSMS;
+    BITBOX_02, SPECTER_DIY, PASSPORT, BLUE_WALLET, KEYSTONE, SEEDSIGNER, CARAVAN, GORDIAN_SEED_TOOL, JADE, LEDGER_NANO_S_PLUS, EPS, TAPSIGNER, SATSCARD, SATOCHIP, LABELS, BSMS;
 
     public static WalletModel getModel(String model) {
         return valueOf(model.toUpperCase(Locale.ROOT));
@@ -68,6 +68,19 @@ public enum WalletModel {
 
     public boolean isCard() {
         return (this == TAPSIGNER || this == SATSCARD);
+    }
+
+    // for card devices that require a PIN code, returns the minimum size of valid PIN code
+    public int getMinPinLength() {
+        if (this == TAPSIGNER || this == SATSCARD){
+            return 6;
+        }
+        else if (this == SATOCHIP){
+            return 4;
+        }
+        else {
+            return 0; // default?
+        }
     }
 
     public static WalletModel fromType(String type) {


### PR DESCRIPTION
This is a pull request to add support for the [Satochip hardware wallet](https://satochip.io/) in Sparrow (see also [this pull request](https://github.com/sparrowwallet/sparrow/pull/1091)).

`getMinPinLength()` is needed because Ssatochip require a PIN that is at least 4 characters in size (compared to 6 for Tapsigner).

`public byte[] getPubKey(Boolean compressed)` is needed because the Satochip protocol needs a public key in uncompressed form to initialize a (encrypted) secure channel with the Sparrow application to communicate securely.