### PR TITLE
build.gradle: Use archiveClassifier for shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ jar {
 
 shadowJar {
     archiveVersion = '0.9'
-    classifier = 'all'
+    archiveClassifier = 'all'
 }
 
 extraJavaModuleInfo {


### PR DESCRIPTION
In `shadowJar` configuration, replace deprecated `classifier` with `archiveClassifier`

(This is necessary to support Gradle 8+)
