### PR TITLE
build.gradle: Upgrade Shadow plugin to 7.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 plugins {
     id 'java-library'
     id 'extra-java-module-info'
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 tasks.withType(AbstractArchiveTask) {


### PR DESCRIPTION
Upgrade Gradle Shadow Plugin to 7.1.2. This version works with the current Gradle wrapper version (7.6) but also works with Gradle 8.5 and JDK 21 (provided the archiveClassifier PR #19 is also applied)