### PR TITLE
Add actual shadowJar plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 plugins {
     id 'java-library'
     id 'extra-java-module-info'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 tasks.withType(AbstractArchiveTask) {


### PR DESCRIPTION
`./gradlew shadowJar` was not working on my machine until I've added an explicit reference to shadowJar plugin.