### PR TITLE
Add challenge-response key derivation interfaces

### DIFF
--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseException.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseException.java
@@ -1,0 +1,11 @@
+package com.sparrowwallet.drongo.crypto;
+
+public class ChallengeResponseException extends Exception {
+    public ChallengeResponseException(String message) {
+        super(message);
+    }
+
+    public ChallengeResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
@@ -34,7 +34,7 @@ public class ChallengeResponseKeyDeriver implements AsymmetricKeyDeriver {
             combined = Sha256Hash.hash(bufferArray);
             return ECKey.fromPrivate(combined);
         } catch(ChallengeResponseException e) {
-            throw new KeyCrypterException("Challenge-response key derivation failed", e);
+            throw new KeyCrypterException(e.getMessage(), e);
         } finally {
             if(innerKeyBytes != null) Arrays.fill(innerKeyBytes, (byte) 0);
             if(hmacResponse != null) Arrays.fill(hmacResponse, (byte) 0);

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
@@ -38,7 +38,7 @@ public class ChallengeResponseKeyDeriver implements AsymmetricKeyDeriver {
                 Arrays.fill(hmacResponse, (byte) 0);
             }
         } catch(ChallengeResponseException e) {
-            throw new KeyCrypterException("Challenge-response failed: " + e.getMessage(), e);
+            throw new KeyCrypterException("Challenge-response key derivation failed", e);
         } finally {
             innerKey.clear();
         }

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
@@ -3,6 +3,7 @@ package com.sparrowwallet.drongo.crypto;
 import com.sparrowwallet.drongo.protocol.Sha256Hash;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 public class ChallengeResponseKeyDeriver implements AsymmetricKeyDeriver {
     private final AsymmetricKeyDeriver innerDeriver;
@@ -19,14 +20,23 @@ public class ChallengeResponseKeyDeriver implements AsymmetricKeyDeriver {
         try {
             byte[] challenge = innerDeriver.getSalt();
             byte[] hmacResponse = provider.getResponse(challenge);
-
             byte[] innerKeyBytes = innerKey.getPrivKeyBytes();
-            ByteBuffer buffer = ByteBuffer.allocate(innerKeyBytes.length + hmacResponse.length);
-            buffer.put(innerKeyBytes);
-            buffer.put(hmacResponse);
+            try {
+                ByteBuffer buffer = ByteBuffer.allocate(innerKeyBytes.length + hmacResponse.length);
+                buffer.put(innerKeyBytes);
+                buffer.put(hmacResponse);
 
-            byte[] combined = Sha256Hash.hash(buffer.array());
-            return ECKey.fromPrivate(combined);
+                byte[] combined = Sha256Hash.hash(buffer.array());
+                try {
+                    return ECKey.fromPrivate(combined);
+                } finally {
+                    Arrays.fill(buffer.array(), (byte) 0);
+                    Arrays.fill(combined, (byte) 0);
+                }
+            } finally {
+                Arrays.fill(innerKeyBytes, (byte) 0);
+                Arrays.fill(hmacResponse, (byte) 0);
+            }
         } catch(ChallengeResponseException e) {
             throw new KeyCrypterException("Challenge-response failed: " + e.getMessage(), e);
         } finally {

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
@@ -17,29 +17,29 @@ public class ChallengeResponseKeyDeriver implements AsymmetricKeyDeriver {
     @Override
     public ECKey deriveECKey(CharSequence password) throws KeyCrypterException {
         ECKey innerKey = innerDeriver.deriveECKey(password);
+        byte[] innerKeyBytes = null;
+        byte[] hmacResponse = null;
+        byte[] bufferArray = null;
+        byte[] combined = null;
         try {
             byte[] challenge = innerDeriver.getSalt();
-            byte[] hmacResponse = provider.getResponse(challenge);
-            byte[] innerKeyBytes = innerKey.getPrivKeyBytes();
-            try {
-                ByteBuffer buffer = ByteBuffer.allocate(innerKeyBytes.length + hmacResponse.length);
-                buffer.put(innerKeyBytes);
-                buffer.put(hmacResponse);
+            hmacResponse = provider.getResponse(challenge);
+            innerKeyBytes = innerKey.getPrivKeyBytes();
 
-                byte[] combined = Sha256Hash.hash(buffer.array());
-                try {
-                    return ECKey.fromPrivate(combined);
-                } finally {
-                    Arrays.fill(buffer.array(), (byte) 0);
-                    Arrays.fill(combined, (byte) 0);
-                }
-            } finally {
-                Arrays.fill(innerKeyBytes, (byte) 0);
-                Arrays.fill(hmacResponse, (byte) 0);
-            }
+            ByteBuffer buffer = ByteBuffer.allocate(innerKeyBytes.length + hmacResponse.length);
+            buffer.put(innerKeyBytes);
+            buffer.put(hmacResponse);
+            bufferArray = buffer.array();
+
+            combined = Sha256Hash.hash(bufferArray);
+            return ECKey.fromPrivate(combined);
         } catch(ChallengeResponseException e) {
             throw new KeyCrypterException("Challenge-response key derivation failed", e);
         } finally {
+            if(innerKeyBytes != null) Arrays.fill(innerKeyBytes, (byte) 0);
+            if(hmacResponse != null) Arrays.fill(hmacResponse, (byte) 0);
+            if(bufferArray != null) Arrays.fill(bufferArray, (byte) 0);
+            if(combined != null) Arrays.fill(combined, (byte) 0);
             innerKey.clear();
         }
     }

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
@@ -1,0 +1,41 @@
+package com.sparrowwallet.drongo.crypto;
+
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+
+import java.nio.ByteBuffer;
+
+public class ChallengeResponseKeyDeriver implements AsymmetricKeyDeriver {
+    private final AsymmetricKeyDeriver innerDeriver;
+    private final ChallengeResponseProvider provider;
+
+    public ChallengeResponseKeyDeriver(AsymmetricKeyDeriver innerDeriver, ChallengeResponseProvider provider) {
+        this.innerDeriver = innerDeriver;
+        this.provider = provider;
+    }
+
+    @Override
+    public ECKey deriveECKey(CharSequence password) throws KeyCrypterException {
+        ECKey innerKey = innerDeriver.deriveECKey(password);
+        try {
+            byte[] challenge = innerDeriver.getSalt();
+            byte[] hmacResponse = provider.getResponse(challenge);
+
+            byte[] innerKeyBytes = innerKey.getPrivKeyBytes();
+            ByteBuffer buffer = ByteBuffer.allocate(innerKeyBytes.length + hmacResponse.length);
+            buffer.put(innerKeyBytes);
+            buffer.put(hmacResponse);
+
+            byte[] combined = Sha256Hash.hash(buffer.array());
+            return ECKey.fromPrivate(combined);
+        } catch(ChallengeResponseException e) {
+            throw new KeyCrypterException("Challenge-response failed: " + e.getMessage(), e);
+        } finally {
+            innerKey.clear();
+        }
+    }
+
+    @Override
+    public byte[] getSalt() {
+        return innerDeriver.getSalt();
+    }
+}

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriver.java
@@ -1,0 +1,50 @@
+package com.sparrowwallet.drongo.crypto;
+
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+public class ChallengeResponseKeyDeriver implements AsymmetricKeyDeriver {
+    private final AsymmetricKeyDeriver innerDeriver;
+    private final ChallengeResponseProvider provider;
+
+    public ChallengeResponseKeyDeriver(AsymmetricKeyDeriver innerDeriver, ChallengeResponseProvider provider) {
+        this.innerDeriver = innerDeriver;
+        this.provider = provider;
+    }
+
+    @Override
+    public ECKey deriveECKey(CharSequence password) throws KeyCrypterException {
+        ECKey innerKey = innerDeriver.deriveECKey(password);
+        byte[] innerKeyBytes = null;
+        byte[] hmacResponse = null;
+        byte[] bufferArray = null;
+        byte[] combined = null;
+        try {
+            byte[] challenge = innerDeriver.getSalt();
+            hmacResponse = provider.getResponse(challenge);
+            innerKeyBytes = innerKey.getPrivKeyBytes();
+
+            ByteBuffer buffer = ByteBuffer.allocate(innerKeyBytes.length + hmacResponse.length);
+            buffer.put(innerKeyBytes);
+            buffer.put(hmacResponse);
+            bufferArray = buffer.array();
+
+            combined = Sha256Hash.hash(bufferArray);
+            return ECKey.fromPrivate(combined);
+        } catch(ChallengeResponseException e) {
+            throw new KeyCrypterException(e.getMessage(), e);
+        } finally {
+            if(innerKeyBytes != null) Arrays.fill(innerKeyBytes, (byte) 0);
+            if(hmacResponse != null) Arrays.fill(hmacResponse, (byte) 0);
+            if(bufferArray != null) Arrays.fill(bufferArray, (byte) 0);
+            if(combined != null) Arrays.fill(combined, (byte) 0);
+        }
+    }
+
+    @Override
+    public byte[] getSalt() {
+        return innerDeriver.getSalt();
+    }
+}

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseProvider.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseProvider.java
@@ -1,0 +1,7 @@
+package com.sparrowwallet.drongo.crypto;
+
+public interface ChallengeResponseProvider {
+    byte[] getResponse(byte[] challenge) throws ChallengeResponseException;
+
+    String getName();
+}

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseProvider.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ChallengeResponseProvider.java
@@ -1,0 +1,5 @@
+package com.sparrowwallet.drongo.crypto;
+
+public interface ChallengeResponseProvider {
+    byte[] getResponse(byte[] challenge) throws ChallengeResponseException;
+}

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ECKey.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ECKey.java
@@ -848,8 +848,11 @@ public class ECKey {
             if(mag != null) {
                 Arrays.fill(mag, 0);
             }
+            Field sigField = BigInteger.class.getDeclaredField("signum");
+            sigField.setAccessible(true);
+            sigField.setInt(priv, 0);
         } catch(NoSuchFieldException | IllegalAccessException e) {
-            // Best-effort: reflection may be blocked by module system
+            log.warn("Could not zero private key via reflection; add --add-opens java.base/java.math=ALL-UNNAMED to JVM args");
         }
     }
 

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ECKey.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ECKey.java
@@ -25,9 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.lang.reflect.Field;
 import java.security.SecureRandom;
 import java.security.SignatureException;
 import java.util.Arrays;

--- a/src/main/java/com/sparrowwallet/drongo/crypto/ECKey.java
+++ b/src/main/java/com/sparrowwallet/drongo/crypto/ECKey.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Field;
 import java.security.SecureRandom;
 import java.security.SignatureException;
 import java.util.Arrays;
@@ -837,8 +838,18 @@ public class ECKey {
     }
 
     public void clear() {
-        for(int i = 0; i < priv.bitLength(); i++) {
-            priv.clearBit(i);
+        if(priv == null) {
+            return;
+        }
+        try {
+            Field magField = BigInteger.class.getDeclaredField("mag");
+            magField.setAccessible(true);
+            int[] mag = (int[]) magField.get(priv);
+            if(mag != null) {
+                Arrays.fill(mag, 0);
+            }
+        } catch(NoSuchFieldException | IllegalAccessException e) {
+            // Best-effort: reflection may be blocked by module system
         }
     }
 

--- a/src/test/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriverTest.java
+++ b/src/test/java/com/sparrowwallet/drongo/crypto/ChallengeResponseKeyDeriverTest.java
@@ -1,0 +1,116 @@
+package com.sparrowwallet.drongo.crypto;
+
+import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+public class ChallengeResponseKeyDeriverTest {
+    private static final byte[] SALT = Utils.hexToBytes("000102030405060708090a0b0c0d0e0f");
+
+    private static ChallengeResponseProvider fixedResponse(byte[] response) {
+        return challenge -> Arrays.copyOf(response, response.length);
+    }
+
+    private static byte[] hmacOfLength(int length, byte fill) {
+        byte[] response = new byte[length];
+        Arrays.fill(response, fill);
+        return response;
+    }
+
+    @Test
+    public void derivesCombinedKey() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        byte[] response = hmacOfLength(20, (byte)0x5a);
+        ChallengeResponseKeyDeriver deriver = new ChallengeResponseKeyDeriver(inner, fixedResponse(response));
+
+        ECKey derived = deriver.deriveECKey("password");
+
+        byte[] innerKeyBytes = inner.deriveECKey("password").getPrivKeyBytes();
+        ByteBuffer buffer = ByteBuffer.allocate(innerKeyBytes.length + response.length);
+        buffer.put(innerKeyBytes);
+        buffer.put(response);
+        ECKey expected = ECKey.fromPrivate(Sha256Hash.hash(buffer.array()));
+
+        Assertions.assertEquals(expected, derived);
+    }
+
+    @Test
+    public void isDeterministic() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        ChallengeResponseKeyDeriver deriver = new ChallengeResponseKeyDeriver(inner, fixedResponse(hmacOfLength(20, (byte)0x11)));
+
+        Assertions.assertEquals(deriver.deriveECKey("password"), deriver.deriveECKey("password"));
+    }
+
+    @Test
+    public void differentResponseGivesDifferentKey() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        ECKey first = new ChallengeResponseKeyDeriver(inner, fixedResponse(hmacOfLength(20, (byte)0x01))).deriveECKey("password");
+        ECKey second = new ChallengeResponseKeyDeriver(inner, fixedResponse(hmacOfLength(20, (byte)0x02))).deriveECKey("password");
+
+        Assertions.assertNotEquals(first, second);
+    }
+
+    @Test
+    public void differentPasswordGivesDifferentKey() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        ChallengeResponseKeyDeriver deriver = new ChallengeResponseKeyDeriver(inner, fixedResponse(hmacOfLength(20, (byte)0x33)));
+
+        Assertions.assertNotEquals(deriver.deriveECKey("password"), deriver.deriveECKey("other"));
+    }
+
+    @Test
+    public void differsFromInnerDeriverAlone() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        ChallengeResponseKeyDeriver deriver = new ChallengeResponseKeyDeriver(inner, fixedResponse(hmacOfLength(20, (byte)0x44)));
+
+        Assertions.assertNotEquals(inner.deriveECKey("password"), deriver.deriveECKey("password"));
+    }
+
+    @Test
+    public void challengeIsTheInnerSalt() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        byte[][] seen = new byte[1][];
+        ChallengeResponseKeyDeriver deriver = new ChallengeResponseKeyDeriver(inner, challenge -> {
+            seen[0] = challenge;
+            return hmacOfLength(20, (byte)0x55);
+        });
+
+        deriver.deriveECKey("password");
+
+        Assertions.assertArrayEquals(SALT, seen[0]);
+        Assertions.assertArrayEquals(SALT, deriver.getSalt());
+    }
+
+    @Test
+    public void deviceFailureBecomesKeyCrypterExceptionPreservingMessage() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        ChallengeResponseKeyDeriver deriver = new ChallengeResponseKeyDeriver(inner, challenge -> {
+            throw new ChallengeResponseException("Security key timed out waiting for touch");
+        });
+
+        KeyCrypterException e = Assertions.assertThrows(KeyCrypterException.class, () -> deriver.deriveECKey("password"));
+        Assertions.assertEquals("Security key timed out waiting for touch", e.getMessage());
+        Assertions.assertInstanceOf(ChallengeResponseException.class, e.getCause());
+    }
+
+    @Test
+    public void acceptsResponseLengthsOtherThanTwenty() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        ECKey key = new ChallengeResponseKeyDeriver(inner, fixedResponse(hmacOfLength(32, (byte)0x66))).deriveECKey("password");
+
+        Assertions.assertNotNull(key);
+    }
+
+    @Test
+    public void emptyPasswordStillMixesTheResponse() {
+        Argon2KeyDeriver inner = new Argon2KeyDeriver(SALT);
+        ChallengeResponseKeyDeriver deriver = new ChallengeResponseKeyDeriver(inner, fixedResponse(hmacOfLength(20, (byte)0x77)));
+
+        Assertions.assertNotEquals(inner.deriveECKey(""), deriver.deriveECKey(""));
+    }
+}


### PR DESCRIPTION
## Summary

Adds the interfaces for using an external challenge-response device (such as a YubiKey in HMAC-SHA1 mode) as a second factor in wallet key derivation.

- `ChallengeResponseProvider` — interface a device implementation satisfies
- `ChallengeResponseKeyDeriver` — wraps an `AsymmetricKeyDeriver`, combining its output with the device response as `SHA256(derivedKey || hmacResponse)`
- `ChallengeResponseException` — device failure, surfaced to the caller as a `KeyCrypterException` preserving the message

Three new files and tests. No existing class is modified.

Intermediate secret buffers are zeroed in a `finally` block.

## Tests

`ChallengeResponseKeyDeriverTest` covers the composition against an independently computed hash, determinism, that a different response or password yields a different key, that the challenge is the inner deriver's salt, exception translation, and that an empty password still mixes the response.

## Dependents

- sparrowwallet/sparrow#1967
