### PR TITLE
Support constructing transactions whose output exceeds input (SIGHASH_ANYONECANPAY workflows)

### DIFF
--- a/src/main/java/com/sparrowwallet/drongo/wallet/TransactionParameters.java
+++ b/src/main/java/com/sparrowwallet/drongo/wallet/TransactionParameters.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 public record TransactionParameters(List<UtxoSelector> utxoSelectors, List<TxoFilter> txoFilters, List<Payment> payments, List<byte[]> opReturns,
                                     Set<WalletNode> excludedChangeNodes, double feeRate, double longTermFeeRate, double minRelayFeeRate, Long fee,
-                                    Integer currentBlockHeight, boolean groupByAddress, boolean includeMempoolOutputs, boolean allowRbf) {
+                                    Integer currentBlockHeight, boolean groupByAddress, boolean includeMempoolOutputs, boolean allowRbf, boolean anyoneCanPay) {
 
     public boolean containsSendMaxPayment() {
         return payments.stream().anyMatch(Payment::isSendMax);

--- a/src/main/java/com/sparrowwallet/drongo/wallet/Wallet.java
+++ b/src/main/java/com/sparrowwallet/drongo/wallet/Wallet.java
@@ -1088,6 +1088,10 @@ public class Wallet extends Persistable implements Comparable<Wallet> {
             throw new InsufficientFundsException("Not enough combined value in all available UTXOs to send a transaction to the provided addresses at this fee rate");
         }
 
+        if(params.anyoneCanPay()) {
+            return createAnyoneCanPayWalletTransaction(params, availableTxos);
+        }
+
         //When a user fee is set, we can calculate the fees to spend all UTXOs because we assume all UTXOs are spendable at a fee rate of 1 sat/vB
         //We can then add the user set fee less this amount as a "phantom payment amount" to the value required to find (which cannot include transaction fees)
         long valueRequiredAmt = totalPaymentAmount + (params.fee() != null ? params.fee() - (totalAvailableValue - maxSpendableAmt) : 0);
@@ -1256,6 +1260,55 @@ public class Wallet extends Persistable implements Comparable<Wallet> {
 
             return new WalletTransaction(this, transaction, params.utxoSelectors(), selectedUtxoSets, txPayments, outputs, differenceAmt);
         }
+    }
+
+    private WalletTransaction createAnyoneCanPayWalletTransaction(TransactionParameters params, Map<BlockTransactionHashIndex, WalletNode> availableTxos) throws InsufficientFundsException {
+        if(availableTxos.isEmpty()) {
+            throw new InsufficientFundsException("No UTXOs available for an anyonecanpay transaction");
+        }
+
+        for(Payment payment : params.payments()) {
+            if(payment instanceof SilentPayment) {
+                throw new IllegalArgumentException("Silent payments are not supported for anyonecanpay transactions");
+            }
+        }
+
+        long sequence = params.allowRbf() ? TransactionInput.SEQUENCE_RBF_ENABLED : TransactionInput.SEQUENCE_RBF_DISABLED;
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        if(params.currentBlockHeight() != null) {
+            transaction.setLocktime(params.currentBlockHeight().longValue());
+        }
+
+        Map<BlockTransactionHashIndex, WalletNode> selectedUtxos = new LinkedHashMap<>(availableTxos);
+        List<Map<BlockTransactionHashIndex, WalletNode>> selectedUtxoSets = List.of(selectedUtxos);
+
+        for(Map.Entry<BlockTransactionHashIndex, WalletNode> selectedUtxo : selectedUtxos.entrySet()) {
+            Transaction prevTx = getWalletTransaction(selectedUtxo.getKey().getHash()).getTransaction();
+            TransactionOutput prevTxOut = prevTx.getOutputs().get((int)selectedUtxo.getKey().getIndex());
+            TransactionInput txInput = addDummySpendingInput(transaction, selectedUtxo.getValue(), prevTxOut);
+            txInput.setSequenceNumber(sequence);
+        }
+
+        List<Payment> txPayments = new ArrayList<>(params.payments());
+        List<WalletTransaction.Output> outputs = new ArrayList<>();
+
+        for(Payment payment : txPayments) {
+            TransactionOutput output = transaction.addOutput(payment.getAmount(), payment.getAddress());
+            outputs.add(new WalletTransaction.PaymentOutput(output, payment));
+        }
+
+        for(byte[] opReturn : params.opReturns()) {
+            TransactionOutput output = transaction.addOutput(0L, new Script(List.of(ScriptChunk.fromOpcode(ScriptOpCodes.OP_RETURN), ScriptChunk.fromData(opReturn))));
+            outputs.add(new WalletTransaction.NonAddressOutput(output));
+        }
+
+        long totalSelectedAmt = selectedUtxos.keySet().stream().mapToLong(BlockTransactionHashIndex::getValue).sum();
+        long totalPaymentAmount = params.getTotalPaymentAmount();
+        long fee = totalSelectedAmt - totalPaymentAmount;
+
+        return new WalletTransaction(this, transaction, params.utxoSelectors(), selectedUtxoSets, txPayments, outputs, fee);
     }
 
     private void applySequenceAntiFeeSniping(Transaction transaction, Map<BlockTransactionHashIndex, WalletNode> selectedUtxos, int currentBlockHeight) {

--- a/src/test/java/com/sparrowwallet/drongo/wallet/WalletTest.java
+++ b/src/test/java/com/sparrowwallet/drongo/wallet/WalletTest.java
@@ -9,11 +9,18 @@ import com.sparrowwallet.drongo.crypto.*;
 import com.sparrowwallet.drongo.policy.Policy;
 import com.sparrowwallet.drongo.policy.PolicyType;
 import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionSignature;
+import com.sparrowwallet.drongo.psbt.PSBT;
 import com.sparrowwallet.drongo.silentpayments.SilentPaymentScanAddress;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class WalletTest {
     @Test
@@ -401,6 +408,74 @@ public class WalletTest {
         keystore.setKeyDerivation(new KeyDerivation("deadbeef", "m/352'/0'/0'"));
         wallet.getKeystores().add(keystore);
         wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.SINGLE_SP, ScriptType.P2TR, wallet.getKeystores(), 1));
+        return wallet;
+    }
+
+    @Test
+    public void anyoneCanPayAllowsOutputExceedingInputs() throws MnemonicException {
+        Wallet wallet = buildFundedP2wpkhWallet(50_000L);
+        WalletNode receive0 = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Payment payment = new Payment(wallet.getAddress(receive0), "test", 100_000L, false);
+        TransactionParameters params = new TransactionParameters(List.of(), List.of(), List.of(payment), List.of(),
+                Set.of(), 1.0, 1.0, 1.0, null, null, false, false, true, true);
+
+        WalletTransaction walletTx = Assertions.assertDoesNotThrow(() -> wallet.createWalletTransaction(params));
+        Assertions.assertNotNull(walletTx);
+        Assertions.assertEquals(1, walletTx.getTransaction().getInputs().size());
+        Assertions.assertEquals(1, walletTx.getTransaction().getOutputs().size());
+        Assertions.assertEquals(-50_000L, walletTx.getFee());
+    }
+
+    @Test
+    public void anyoneCanPayPsbtSignsWithAnyoneCanPaySigHash() throws MnemonicException {
+        Wallet wallet = buildFundedP2wpkhWallet(50_000L);
+        WalletNode receive0 = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Payment payment = new Payment(wallet.getAddress(receive0), "test", 100_000L, false);
+        TransactionParameters params = new TransactionParameters(List.of(), List.of(), List.of(payment), List.of(),
+                Set.of(), 1.0, 1.0, 1.0, null, null, false, false, true, true);
+
+        WalletTransaction walletTx = Assertions.assertDoesNotThrow(() -> wallet.createWalletTransaction(params));
+        PSBT psbt = walletTx.createPSBT();
+        Assertions.assertEquals(1, psbt.getPsbtInputs().size());
+
+        psbt.getPsbtInputs().forEach(psbtInput -> psbtInput.setSigHash(SigHash.ANYONECANPAY_ALL));
+        wallet.sign(psbt);
+
+        TransactionSignature signature = psbt.getPsbtInputs().getFirst().getPartialSignatures().values().iterator().next();
+        Assertions.assertTrue(signature.anyoneCanPay());
+        Assertions.assertEquals((byte)0x81, signature.sighashFlags);
+    }
+
+    @Test
+    public void standardWalletThrowsInsufficientFunds() throws MnemonicException {
+        Wallet wallet = buildFundedP2wpkhWallet(50_000L);
+        WalletNode receive0 = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Payment payment = new Payment(wallet.getAddress(receive0), "test", 100_000L, false);
+        TransactionParameters params = new TransactionParameters(List.of(), List.of(), List.of(payment), List.of(),
+                Set.of(), 1.0, 1.0, 1.0, null, null, false, false, true, false);
+
+        Assertions.assertThrows(InsufficientFundsException.class, () -> wallet.createWalletTransaction(params));
+    }
+
+    private Wallet buildFundedP2wpkhWallet(long utxoValue) throws MnemonicException {
+        String words = "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor";
+        DeterministicSeed seed = new DeterministicSeed(words, "pp", 0, DeterministicSeed.Type.BIP39);
+        Wallet wallet = new Wallet();
+        wallet.setPolicyType(PolicyType.SINGLE_HD);
+        wallet.setScriptType(ScriptType.P2WPKH);
+        Keystore keystore = Keystore.fromSeed(seed, PolicyType.SINGLE_HD, wallet.getScriptType().getDefaultDerivation());
+        wallet.getKeystores().add(keystore);
+        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.SINGLE_HD, ScriptType.P2WPKH, wallet.getKeystores(), 1));
+
+        WalletNode receive0 = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Transaction fundingTx = new Transaction();
+        fundingTx.addOutput(utxoValue, receive0.getOutputScript());
+        BlockTransaction blockTx = new BlockTransaction(fundingTx.getTxId(), 100, new Date(), null, fundingTx);
+        wallet.updateTransactions(Map.of(fundingTx.getTxId(), blockTx));
+
+        BlockTransactionHashIndex utxo = new BlockTransactionHashIndex(fundingTx.getTxId(), 100, new Date(), null, 0, utxoValue);
+        receive0.getTransactionOutputs().add(utxo);
+
         return wallet;
     }
 }


### PR DESCRIPTION
`createWalletTransaction` refuses to build any transaction whose outputs are worth more than its inputs, throwing `InsufficientFundsException` before construction. That guard is correct for an ordinary spend, but it rules out the family of constructions built on `SIGHASH_ANYONECANPAY`, where a signer commits an input to a set of outputs and other parties add their own inputs afterwards. Because each signature commits to the outputs but not to the full input set, no one can be cheated and nothing is broadcastable until the inputs collectively cover the outputs. The same primitive underlies assurance contracts and pledges (Lighthouse, Semaphore), atomic swaps (the inscription marketplaces use `SINGLE|ANYONECANPAY`), and collaborative payments where several parties co-fund one set of outputs. This is the construction requested in [#706](https://github.com/sparrowwallet/sparrow/issues/706).

The change adds a boolean `anyoneCanPay` field to `TransactionParameters`. When it's set, `createWalletTransaction` takes a dedicated path that spends the wallet's available inputs into the requested outputs without requiring that the inputs cover them. The field defaults to false at every construction site, so existing behaviour is fully preserved and the standard path — both pre-fund checks and the selection loop — is left untouched. The new path keeps an empty-wallet guard, so an anyonecanpay request with nothing to contribute still fails clearly, and it rejects silent payments rather than building toward a placeholder address.

I've kept this to transaction construction on purpose and left sighash selection to signing, where it already lives. drongo and Sparrow already sign `ALL|ANYONECANPAY` correctly, and the transaction view already offers a sighash selector, so the only missing piece was the ability to build the transaction at all. Setting a sighash here would also be premature, since the right variant depends on the use case — `ALL|ANYONECANPAY` for pledges, `SINGLE|ANYONECANPAY` for swaps — and is really the signer's choice rather than the builder's.

Three tests cover the new path: one builds a transaction whose output is twice its single input, one confirms the resulting PSBT signs as `ALL|ANYONECANPAY` (sighash `0x81`), and one confirms that an ordinary request with the flag unset still throws.
