### PR TITLE
Add WalletModel.BANSHEE

### DIFF
--- a/src/main/java/com/sparrowwallet/drongo/wallet/WalletModel.java
+++ b/src/main/java/com/sparrowwallet/drongo/wallet/WalletModel.java
@@ -6,7 +6,7 @@ public enum WalletModel {
     SEED, SPARROW, BITCOIN_CORE, ELECTRUM, TREZOR_1, TREZOR_T, COLDCARD, LEDGER_NANO_S, LEDGER_NANO_X, DIGITALBITBOX_01, KEEPKEY, SPECTER_DESKTOP, COBO_VAULT,
     BITBOX_02, SPECTER_DIY, PASSPORT, BLUE_WALLET, KEYSTONE, SEEDSIGNER, CARAVAN, GORDIAN_SEED_TOOL, JADE, LEDGER_NANO_S_PLUS, EPS, TAPSIGNER, SATSCARD, LABELS,
     BSMS, KRUX, SATOCHIP, TRANSACTIONS, AIRGAP_VAULT, TREZOR_SAFE_3, SATSCHIP, SAMOURAI, TREZOR_SAFE_5, LEDGER_STAX, LEDGER_FLEX, ONEKEY_CLASSIC_1S, ONEKEY_PRO,
-    KEYCARD_SHELL, KEYCARD, TREZOR_SAFE_7, LEDGER_NANO_GEN5, ERA_WALLET;
+    KEYCARD_SHELL, KEYCARD, TREZOR_SAFE_7, LEDGER_NANO_GEN5, ERA_WALLET, BANSHEE;
 
     public static WalletModel getModel(String model) {
         return valueOf(model.toUpperCase(Locale.ROOT));
@@ -70,7 +70,7 @@ public enum WalletModel {
 
     public boolean alwaysIncludeNonWitnessUtxo() {
         if(this == COLDCARD || this == COBO_VAULT || this == PASSPORT || this == KEYSTONE || this == GORDIAN_SEED_TOOL || this == SEEDSIGNER || this == KRUX || this == JADE ||
-           this == TAPSIGNER || this == SATOCHIP || this == KEYCARD_SHELL || this == KEYCARD || this == ERA_WALLET) {
+           this == TAPSIGNER || this == SATOCHIP || this == KEYCARD_SHELL || this == KEYCARD || this == ERA_WALLET || this == BANSHEE) {
             return false;
         }
 
@@ -91,7 +91,7 @@ public enum WalletModel {
 
     public boolean hasUsb() {
         return (this == TREZOR_1 || this == TREZOR_T || this == TREZOR_SAFE_3 || this == TREZOR_SAFE_5 || this == TREZOR_SAFE_7 || this == LEDGER_NANO_S || this == LEDGER_NANO_X || this == LEDGER_NANO_S_PLUS ||
-                this == LEDGER_STAX || this == LEDGER_FLEX || this == LEDGER_NANO_GEN5 || this == DIGITALBITBOX_01 || this == BITBOX_02 || this == COLDCARD || this == KEEPKEY || this == JADE || this == ONEKEY_CLASSIC_1S || this == ONEKEY_PRO);
+                this == LEDGER_STAX || this == LEDGER_FLEX || this == LEDGER_NANO_GEN5 || this == DIGITALBITBOX_01 || this == BITBOX_02 || this == COLDCARD || this == KEEPKEY || this == JADE || this == ONEKEY_CLASSIC_1S || this == ONEKEY_PRO || this == BANSHEE);
     }
 
     public int getMinPinLength() {


### PR DESCRIPTION
Adds `WalletModel.BANSHEE` for the Banshee open-source Bitcoin hardware wallet (LilyGo T-Display S3).

Required for Lark/Sparrow integration (companion PR to sparrowwallet/lark).

**Banshee** is an open-source Bitcoin hardware wallet on LilyGo T-Display S3 (ESP32-S3).

- Repository: https://github.com/CuseTheJuice/my-banshee-hardware-app
- USB: Espressif `303a:b05e` (distinct from Jade `303a:4001`)
- Open-source firmware with documented newline-delimited serial protocol (115200 baud)
- BIP39 seed on device; xpub export and PSBT signing with on-device BOOT confirmation
- Vendor commits to maintaining firmware and this driver

Supported in v1: BIP84 native segwit and legacy P2PKH PSBT inputs. No Taproot or multisig yet.

Changes:
- Add `BANSHEE` to `WalletModel` enum
- Include in `alwaysIncludeNonWitnessUtxo()` (same as Jade)
- Include in `hasUsb()`

Made with [Cursor](https://cursor.com)