### PR TITLE
Sort silent payment codes sharing a scan key before assigning k

### DIFF
--- a/src/main/java/com/sparrowwallet/drongo/silentpayments/SilentPaymentAddress.java
+++ b/src/main/java/com/sparrowwallet/drongo/silentpayments/SilentPaymentAddress.java
@@ -27,9 +27,12 @@ public class SilentPaymentAddress {
         return spendAddress;
     }
 
+    public byte[] getKeyBytes() {
+        return Utils.concat(scanAddress.getPubKey(), spendAddress.getPubKey());
+    }
+
     public String getAddress() {
-        byte[] keys = Utils.concat(scanAddress.getPubKey(), spendAddress.getPubKey());
-        return Bech32.encode(Network.get().getSilentPaymentsAddressHrp(), VERSION, Bech32.Encoding.BECH32M, keys);
+        return Bech32.encode(Network.get().getSilentPaymentsAddressHrp(), VERSION, Bech32.Encoding.BECH32M, getKeyBytes());
     }
 
     public static SilentPaymentAddress from(String address) {

--- a/src/main/java/com/sparrowwallet/drongo/silentpayments/SilentPaymentUtils.java
+++ b/src/main/java/com/sparrowwallet/drongo/silentpayments/SilentPaymentUtils.java
@@ -275,9 +275,20 @@ public class SilentPaymentUtils {
         }
     }
 
+    /**
+     * Groups the supplied silent payments by scan key, ordering each group as BIP375 requires for k assignment:
+     * codes sharing a scan key are sorted lexicographically ascending, and codes sharing both scan and spend keys
+     * are ordered by ascending output index. The supplied collection is in output order, so the stable sort below
+     * provides the second ordering without needing the indices themselves.
+     * <p>
+     * Codes are compared as the scan and spend key bytes carried in PSBT_OUT_SP_V0_INFO.
+     */
     public static Map<ECKey, List<SilentPayment>> getScanKeyGroups(Collection<SilentPayment> silentPayments) {
+        List<SilentPayment> ordered = new ArrayList<>(silentPayments);
+        ordered.sort(Comparator.comparing(silentPayment -> silentPayment.getSilentPaymentAddress().getKeyBytes(), new Utils.LexicographicByteArrayComparator()));
+
         Map<ECKey, List<SilentPayment>> scanKeyGroups = new LinkedHashMap<>();
-        for(SilentPayment silentPayment : silentPayments) {
+        for(SilentPayment silentPayment : ordered) {
             SilentPaymentAddress address = silentPayment.getSilentPaymentAddress();
             List<SilentPayment> scanKeyGroup = scanKeyGroups.computeIfAbsent(address.getScanKey(), _ -> new ArrayList<>());
             scanKeyGroup.add(silentPayment);

--- a/src/test/java/com/sparrowwallet/drongo/silentpayments/SilentPaymentUtilsTest.java
+++ b/src/test/java/com/sparrowwallet/drongo/silentpayments/SilentPaymentUtilsTest.java
@@ -623,6 +623,33 @@ public class SilentPaymentUtilsTest {
         Assertions.assertEquals("2e847bb01d1b491da512ddd760b8509617ee38057003d6115d00ba562451323a", Utils.bytesToHex(silentPayments.getLast().getAddress().getData()));
     }
 
+    @Test
+    public void testBip375ThreeOutputsSameScanKey() throws InvalidSilentPaymentException {
+        // BIP375 test vectors v1.1.1, https://github.com/bitcoin/bips/pull/2207
+        // "can finalize: three sp outputs (same scan key) - output 0 uses label=1, outputs 1 and 2 uses label=2 (same spend key)"
+        // Ascending code order places the two 032193ad... outputs ahead of 03d43158..., so outputs 1 and 2 take
+        // k=0 and k=1 in output index order and output 0 takes k=2, inverting the output ordering entirely.
+        ECKey scanKey = ECKey.fromPublicOnly(Utils.hexToBytes("028b790e0987fde9f0d12398eb6be30c7376793c647865a2a02f2efc960d966568"));
+        ECKey spendKeyLabel1 = ECKey.fromPublicOnly(Utils.hexToBytes("03d431588dee61ab3a39725b299c3742dc66a0861decf591b423b0e527070f8234"));
+        ECKey spendKeyLabel2 = ECKey.fromPublicOnly(Utils.hexToBytes("032193ad0c875fac5243738022900a7724c6175ddac9944165aab457aadf9c4f3c"));
+
+        List<SilentPayment> silentPayments = List.of(new SilentPayment(new SilentPaymentAddress(scanKey, spendKeyLabel1), "Output 0", 0, false),
+                new SilentPayment(new SilentPaymentAddress(scanKey, spendKeyLabel2), "Output 1", 0, false),
+                new SilentPayment(new SilentPaymentAddress(scanKey, spendKeyLabel2), "Output 2", 0, false));
+
+        ECKey summedPrivateKey = ECKey.fromPrivate(Utils.hexToBytes("7e31eeeb1aa2597b6d63b357541461d75ddae76b7603d24619f5ebed9e88ec31"));
+        Set<HashIndex> outpoints = Set.of(new HashIndex(Sha256Hash.wrap("4a9800c78110ea283ed15d2e53dd79401eff2313771a2ab114ab0b3b6617a718"), 0));
+
+        SilentPaymentUtils.computeOutputAddresses(silentPayments, summedPrivateKey, outpoints);
+        Assertions.assertEquals(3, silentPayments.size());
+        Assertions.assertEquals("Output 0", silentPayments.getFirst().getLabel());
+        Assertions.assertEquals("1bffa10fdaa2502c2f0c9285fe0af19a50f8515e3b6dfbf56de850d999014400", Utils.bytesToHex(silentPayments.getFirst().getAddress().getData()));
+        Assertions.assertEquals("Output 1", silentPayments.get(1).getLabel());
+        Assertions.assertEquals("884da6708c82b9b56c98bd3be6e5f53894bb1bfd90bfacf894025570f6bd5305", Utils.bytesToHex(silentPayments.get(1).getAddress().getData()));
+        Assertions.assertEquals("Output 2", silentPayments.getLast().getLabel());
+        Assertions.assertEquals("d291d339280e0c86e2c708a591f8e8e2f892d12a7cfe8510b667799b71131c86", Utils.bytesToHex(silentPayments.getLast().getAddress().getData()));
+    }
+
     // BIP352 key sum tests.
 
     @Test


### PR DESCRIPTION
When a transaction has two or more silent payment outputs sharing a scan key, Sparrow and SeedSigner assigned k in different orders and derived different output addresses.

@nottanveer discovered this [issue](https://github.com/selfcustody/krux/pull/925#issuecomment-5394096936) when testing Sparrow and SeedSigner - Thank you for sharing!

BIP375 Text:
> If there are multiple silent payment codes with the same scan key, sort the codes lexicographically in ascending order to determine the ordering of the k value. If there are multiple silent payment codes with both the same scan and spend keys, sort the subgroup by output index in ascending order.

Test `testBip375ThreeOutputsSameScanKey` clones "can finalize: three sp outputs (same scan key) - output 0 uses label=1, outputs 1 and 2 uses label=2 (same spend key)" from BIP375 v1.1.1 test vectors proposed in BIPs [PR 2207](https://github.com/bitcoin/bips/pull/2207). Note that v1.1.1 is still proposed, waiting for BIP authors to confirm spec interpretation is accurate.

Happy to address any requested changes or close this PR in favor of your solution.